### PR TITLE
ci: compliance: use py-versions from requirements-fixed.txt

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -21,13 +21,15 @@ jobs:
         key: ${{ runner.os }}-doc-pip
 
     - name: Install python dependencies
+      with:
+        path: ncs/nrf
       run: |
         pip3 install -U pip
         pip3 install  -U setuptools
         export PATH="$HOME/.local/bin:$PATH"
         pip3 install  -U wheel
-        pip3 install  -U python-magic junitparser==1.6.3 gitlint pylint pykwalify
-        pip3 install --user -U west
+        grep -E "python-magic|junitparser|gitlint|pylint|pykwalify" scripts/requirements-fixed.txt | xargs pip3 install -U
+        grep -E "west" scripts/requirements-fixed.txt | xargs pip3 install -U
         pip3 show -f west
 
     - name: West init and update


### PR DESCRIPTION
pylint==2.7.0 cause false failures for duplicate code
With this change, compliance workflow uses pylint==2.6.0

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>