### PR TITLE
Sanitize github action inputs and fix vulnerabilities

### DIFF
--- a/.github/workflows/license-reusable.yml
+++ b/.github/workflows/license-reusable.yml
@@ -31,6 +31,10 @@ on:
         type: string
         default: nrf/scripts/ci/license_allow_list.yaml
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   license_job:
     runs-on: ubuntu-24.04
@@ -62,13 +66,14 @@ jobs:
       working-directory: ncs
       env:
         PR_REF: ${{ github.event.pull_request.head.sha }}
+        MODULE_PATH: ${{ inputs.path }}
       run: |
         export PATH="$HOME/.local/bin:$PATH"
         export PATH="$HOME/bin:$PATH"
         west zephyr-export
         echo "ZEPHYR_BASE=$(pwd)/zephyr" >> $GITHUB_ENV
         # debug
-        ( cd ${{ inputs.path }}; echo "${{ inputs.path }}"; git log --pretty=oneline --max-count=10 )
+        ( cd "${MODULE_PATH}"; echo "${MODULE_PATH}"; git log --pretty=oneline --max-count=10 )
         ( cd nrf; echo "nrf"; git log --pretty=oneline --max-count=10 )
         ( cd zephyr; echo "zephyr"; git log --pretty=oneline --max-count=10 )
 
@@ -81,6 +86,8 @@ jobs:
       env:
         BASE_REF: ${{ github.base_ref }}
         ZEPHYR_BASE: ${{ env.ZEPHYR_BASE }}
+        LICENSE_ALLOW_LIST: ${{ inputs.license_allow_list }}
+        MODULE_PATH: ${{ inputs.path }}
       working-directory: ncs/${{ inputs.path }}
       if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
       run: |
@@ -88,7 +95,7 @@ jobs:
         export PATH="$HOME/bin:$PATH"
         ${ZEPHYR_BASE}/../nrf/scripts/ci/check_license.py \
             --github \
-            -l ${ZEPHYR_BASE}/../${{ inputs.license_allow_list }} \
+            -l ${ZEPHYR_BASE}/../"${LICENSE_ALLOW_LIST}" \
             -c origin/${BASE_REF}..
 
     - name: Upload results


### PR DESCRIPTION
Sanitize GitHub Actions inputs `path` and `license_allow_list` to fix critical script injection vulnerabilities.

The workflow directly interpolated `inputs.path` and `inputs.license_allow_list` into shell commands, creating script injection vulnerabilities. This PR fixes these by using environment variables and proper quoting, and adds explicit workflow permissions to prevent arbitrary command execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-98982338-b969-443a-8425-3867a32cbb61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-98982338-b969-443a-8425-3867a32cbb61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

