### PR TITLE
Sanitize github action inputs and fix vulnerabilities

### DIFF
--- a/.github/workflows/license-reusable.yml
+++ b/.github/workflows/license-reusable.yml
@@ -66,13 +66,14 @@ jobs:
       working-directory: ncs
       env:
         PR_REF: ${{ github.event.pull_request.head.sha }}
+        MODULE_PATH: ${{ inputs.path }}
       run: |
         export PATH="$HOME/.local/bin:$PATH"
         export PATH="$HOME/bin:$PATH"
         west zephyr-export
         echo "ZEPHYR_BASE=$(pwd)/zephyr" >> $GITHUB_ENV
-        # debug
-        ( cd ${{ inputs.path }}; echo "${{ inputs.path }}"; git log --pretty=oneline --max-count=10 )
+        # debug - use environment variable to prevent injection
+        ( cd "$MODULE_PATH"; echo "$MODULE_PATH"; git log --pretty=oneline --max-count=10 )
         ( cd nrf; echo "nrf"; git log --pretty=oneline --max-count=10 )
         ( cd zephyr; echo "zephyr"; git log --pretty=oneline --max-count=10 )
 
@@ -85,15 +86,18 @@ jobs:
       env:
         BASE_REF: ${{ github.base_ref }}
         ZEPHYR_BASE: ${{ env.ZEPHYR_BASE }}
+        MODULE_PATH: ${{ inputs.path }}
+        LICENSE_ALLOW_LIST: ${{ inputs.license_allow_list }}
       working-directory: ncs/${{ inputs.path }}
       if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
       run: |
         export PATH="$HOME/.local/bin:$PATH"
         export PATH="$HOME/bin:$PATH"
-        ${ZEPHYR_BASE}/../nrf/scripts/ci/check_license.py \
+        # Use environment variables to prevent shell injection
+        "${ZEPHYR_BASE}/../nrf/scripts/ci/check_license.py" \
             --github \
-            -l ${ZEPHYR_BASE}/../${{ inputs.license_allow_list }} \
-            -c origin/${BASE_REF}..
+            -l "${ZEPHYR_BASE}/../${LICENSE_ALLOW_LIST}" \
+            -c "origin/${BASE_REF}.."
 
     - name: Upload results
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4


### PR DESCRIPTION
Fix script injection vulnerabilities in `license-reusable.yml` GitHub Actions workflow by sanitizing untrusted inputs.

The workflow directly interpolated untrusted user inputs (`inputs.path`, `inputs.license_allow_list`, `github.base_ref`) into shell commands, making it vulnerable to script injection attacks. An attacker could execute arbitrary commands by providing malicious input values. This PR mitigates these risks by using environment variables and proper quoting.

---
<a href="https://cursor.com/background-agent?bcId=bc-f732a81e-f0d3-428c-b3f4-807e48dc494f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f732a81e-f0d3-428c-b3f4-807e48dc494f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sanitizes and quotes inputs in the reusable license check workflow, switching to env vars for paths/allow-list and hardening command invocations.
> 
> - **CI Workflow (`.github/workflows/license-reusable.yml`)**:
>   - **Security hardening**:
>     - Use env vars (`MODULE_PATH`, `LICENSE_ALLOW_LIST`) instead of direct input interpolation.
>     - Quote paths/args in `cd` and `check_license.py` invocation (`-l`, `-c`).
>   - **Adjustments**:
>     - Preserve `ZEPHYR_BASE` via `$GITHUB_ENV` and use it in commands.
>     - Update debug logs to use quoted env vars.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86f847b8eb263a27a6673eadf88aa9ed6bdfe35a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->