### PR TITLE
Sanitize github action inputs and fix vulnerabilities

### DIFF
--- a/.github/workflows/license-reusable.yml
+++ b/.github/workflows/license-reusable.yml
@@ -40,11 +40,55 @@ jobs:
     runs-on: ubuntu-24.04
     name: Run license checks on patch series (PR)
     steps:
+    - name: Validate inputs
+      run: |
+        # Validate path input - must not contain path traversal, absolute paths, shell metacharacters, or newlines
+        if [[ "${{ inputs.path }}" =~ \.\./|\;|\||\&|\$\(|\`|\<|\>|[ ]{2,}|\n|\r|^/ ]]; then
+          echo "Error: Invalid characters detected in path input"
+          exit 1
+        fi
+        
+        # Check for absolute path separately for clearer error message
+        if [[ "${{ inputs.path }}" =~ ^/ ]]; then
+          echo "Error: Absolute paths not allowed. Path must be relative to west workspace."
+          exit 1
+        fi
+        
+        # Check for newlines that could enable GITHUB_ENV injection
+        if [[ "${{ inputs.path }}" == *$'\n'* ]] || [[ "${{ inputs.path }}" == *$'\r'* ]]; then
+          echo "Error: Newline characters detected in path input - potential GITHUB_ENV injection"
+          exit 1
+        fi
+        
+        # Validate license_allow_list input
+        if [[ "${{ inputs.license_allow_list }}" =~ \.\./|\;|\||\&|\$\(|\`|\<|\>|[ ]{2,}|\n|\r|^/ ]]; then
+          echo "Error: Invalid characters detected in license_allow_list input"
+          exit 1
+        fi
+        
+        # Check for absolute path in license_allow_list
+        if [[ "${{ inputs.license_allow_list }}" =~ ^/ ]]; then
+          echo "Error: Absolute paths not allowed. License allow list path must be relative to west workspace."
+          exit 1
+        fi
+        
+        # Check for newlines in license_allow_list
+        if [[ "${{ inputs.license_allow_list }}" == *$'\n'* ]] || [[ "${{ inputs.license_allow_list }}" == *$'\r'* ]]; then
+          echo "Error: Newline characters detected in license_allow_list input - potential GITHUB_ENV injection"
+          exit 1
+        fi
+        
+        # Set sanitized environment variables
+        echo "SANITIZED_PATH=${{ inputs.path }}" >> $GITHUB_ENV
+        echo "SANITIZED_LICENSE_ALLOW_LIST=${{ inputs.license_allow_list }}" >> $GITHUB_ENV
+
     - name: Checkout sources
       uses: nrfconnect/action-checkout-west-update@main
+      env:
+        MODULE_PATH: ${{ env.SANITIZED_PATH }}
       with:
         git-fetch-depth: 0
-        path: ncs/${{ inputs.path }}
+        path: ncs/${{ env.SANITIZED_PATH }}
         west-update-args: '-n zephyr bsim'
 
     - name: cache-pip
@@ -66,13 +110,14 @@ jobs:
       working-directory: ncs
       env:
         PR_REF: ${{ github.event.pull_request.head.sha }}
+        MODULE_PATH: ${{ env.SANITIZED_PATH }}
       run: |
         export PATH="$HOME/.local/bin:$PATH"
         export PATH="$HOME/bin:$PATH"
         west zephyr-export
         echo "ZEPHYR_BASE=$(pwd)/zephyr" >> $GITHUB_ENV
-        # debug
-        ( cd ${{ inputs.path }}; echo "${{ inputs.path }}"; git log --pretty=oneline --max-count=10 )
+        # debug - use environment variables to prevent injection
+        ( cd "${MODULE_PATH}"; echo "Module path: ${MODULE_PATH}"; git log --pretty=oneline --max-count=10 )
         ( cd nrf; echo "nrf"; git log --pretty=oneline --max-count=10 )
         ( cd zephyr; echo "zephyr"; git log --pretty=oneline --max-count=10 )
 
@@ -85,21 +130,26 @@ jobs:
       env:
         BASE_REF: ${{ github.base_ref }}
         ZEPHYR_BASE: ${{ env.ZEPHYR_BASE }}
-      working-directory: ncs/${{ inputs.path }}
+        MODULE_PATH: ${{ env.SANITIZED_PATH }}
+        LICENSE_ALLOW_LIST: ${{ env.SANITIZED_LICENSE_ALLOW_LIST }}
+      working-directory: ncs
       if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
       run: |
         export PATH="$HOME/.local/bin:$PATH"
         export PATH="$HOME/bin:$PATH"
-        ${ZEPHYR_BASE}/../nrf/scripts/ci/check_license.py \
+        cd "${MODULE_PATH}"
+        "${ZEPHYR_BASE}/../nrf/scripts/ci/check_license.py" \
             --github \
-            -l ${ZEPHYR_BASE}/../${{ inputs.license_allow_list }} \
-            -c origin/${BASE_REF}..
+            -l "${ZEPHYR_BASE}/../${LICENSE_ALLOW_LIST}" \
+            -c "origin/${BASE_REF}.."
 
     - name: Upload results
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       continue-on-error: true
       if: always() && contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
+      env:
+        MODULE_PATH: ${{ env.SANITIZED_PATH }}
       with:
         name: licenses.xml
-        path: ncs/${{ inputs.path }}/licenses.xml
+        path: ncs/${{ env.MODULE_PATH }}/licenses.xml
         overwrite: true


### PR DESCRIPTION
Sanitize inputs in `license-reusable.yml` to fix GitHub Actions command injection and path traversal vulnerabilities.

The original workflow directly interpolated user-provided inputs into shell commands and file paths, allowing for potential command injection and path traversal. This PR introduces input validation, uses sanitized environment variables, and ensures proper shell quoting to prevent these attacks.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5681d52-22ec-4ee8-9050-20ee3b582c3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5681d52-22ec-4ee8-9050-20ee3b582c3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sanitizes and safely uses inputs in the reusable license workflow, hardening it against command injection and path traversal while adjusting paths/working directory accordingly.
> 
> - **CI (GitHub Actions)** in `.github/workflows/license-reusable.yml`:
>   - **Input sanitization**: Validate `inputs.path` and `inputs.license_allow_list` to block traversal/injection; export `SANITIZED_PATH` and `SANITIZED_LICENSE_ALLOW_LIST`.
>   - **Safe variable usage**: Replace direct interpolation with quoted env vars (`MODULE_PATH`, `LICENSE_ALLOW_LIST`) across checkout, debug logs, license check, and artifact upload.
>   - **Execution flow**: Change to `working-directory: ncs` and `cd "${MODULE_PATH}"` before running `check_license.py`; ensure all paths/args are quoted.
>   - **Artifacts**: Upload `licenses.xml` from `ncs/${{ env.MODULE_PATH }}/licenses.xml` using sanitized path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c8143eb09564782bda333d1fd0f177f42718211. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->